### PR TITLE
Filter empty domains

### DIFF
--- a/src/Resources/contao/classes/Referrer/ProviderParser.php
+++ b/src/Resources/contao/classes/Referrer/ProviderParser.php
@@ -72,7 +72,7 @@ class ProviderParser
 
     public function cleanProviderList()
     {
-        $this->arrReferrerSpammer = array_unique($this->arrReferrerSpammer); // doppelte Elemente löschen
+        $this->arrReferrerSpammer = array_filter(array_unique($this->arrReferrerSpammer)); // doppelte Elemente löschen
 
         foreach ($this->arrReferrerSpammer as &$url)
         {


### PR DESCRIPTION
With some of the lists the following error can occur:

```
ValueError:
idn_to_ascii(): Argument #1 ($domain) must not be empty

  at vendor\bugbuster\contao-botdetection-bundle\src\Resources\contao\classes\Referrer\ProviderParser.php:86
  at idn_to_ascii('')
     (vendor\bugbuster\contao-botdetection-bundle\src\Resources\contao\classes\Referrer\ProviderParser.php:86)
  at BugBuster\BotDetection\Referrer\ProviderParser->cleanProviderList()
     (vendor\bugbuster\contao-botdetection-bundle\src\Resources\contao\modules\ModuleBotDetection.php:169)
  at BugBuster\BotDetection\ModuleBotDetection->prefillCache()
     (vendor\bugbuster\contao-botdetection-bundle\src\Resources\contao\modules\ModuleBotDetection.php:65)
  at BugBuster\BotDetection\ModuleBotDetection->__construct()
```

This is because `$this->arrReferrerSpammer` can contain empty entries. This PR fixes that by filtering empty entries via `array_filter`. Alternatively a `trim()` in line 60 would also work as the empty entry is caused by the `\n` at the end of the file.